### PR TITLE
Fix fsdgenpython loop limit regression

### DIFF
--- a/src/Facility.CodeGen.Python/CodeTemplateUtility.cs
+++ b/src/Facility.CodeGen.Python/CodeTemplateUtility.cs
@@ -10,7 +10,14 @@ namespace Facility.CodeGen.Python
 	{
 		public static string Render(string templateText, CodeTemplateGlobals globals)
 		{
-			var templateContext = new TemplateContext { StrictVariables = true, MemberRenamer = x => x.Name };
+			var templateContext = new TemplateContext
+			{
+				StrictVariables = true,
+				MemberRenamer = x => x.Name,
+
+				// Preserve support for large schemas; newer Scriban versions cap loop iterations at 1000 by default.
+				LoopLimit = 0,
+			};
 			templateContext.PushCulture(new CultureInfo("en-US"));
 			templateContext.PushGlobal(CreateScriptObject(globals));
 

--- a/tests/Facility.CodeGen.Python.UnitTests/PythonGeneratorTests.cs
+++ b/tests/Facility.CodeGen.Python.UnitTests/PythonGeneratorTests.cs
@@ -10,19 +10,47 @@ namespace Facility.CodeGen.Python.UnitTests
 		[Test]
 		public void GenerateExampleApiSuccess()
 		{
-			ServiceInfo service;
-			const string fileName = "Facility.CodeGen.Python.UnitTests.ConformanceApi.fsd";
-			var parser = new FsdParser(new FsdParserSettings { SupportsEvents = true });
-			var stream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream(fileName);
-			Assert.That(stream, Is.Not.Null);
-			using (var reader = new StreamReader(stream!))
-				service = parser.ParseDefinition(new ServiceDefinitionText(Path.GetFileName(fileName), reader.ReadToEnd()));
+			var generator = CreateGenerator();
+			generator.GenerateOutput(ParseEmbeddedFsd("Facility.CodeGen.Python.UnitTests.ConformanceApi.fsd"));
+		}
 
-			var generator = new PythonGenerator
+		[Test]
+		public void GenerateLargeDataSuccess()
+		{
+			var fieldLines = string.Join(Environment.NewLine, Enumerable.Range(1, 1001).Select(index => $"\t\tfield{index}: string;"));
+			var fsdText =
+				$$"""
+				service LargeApi
+				{
+					data LargeData
+					{
+				{{fieldLines}}
+					}
+				}
+				""";
+
+			var generator = CreateGenerator();
+			generator.GenerateOutput(ParseFsd("LargeApi.fsd", fsdText));
+		}
+
+		private static PythonGenerator CreateGenerator() =>
+			new()
 			{
 				GeneratorName = "PythonGeneratorTests",
 			};
-			generator.GenerateOutput(service);
+
+		private static ServiceInfo ParseEmbeddedFsd(string fileName)
+		{
+			var stream = typeof(PythonGeneratorTests).GetTypeInfo().Assembly.GetManifestResourceStream(fileName);
+			Assert.That(stream, Is.Not.Null);
+			using var reader = new StreamReader(stream!);
+			return ParseFsd(Path.GetFileName(fileName), reader.ReadToEnd());
+		}
+
+		private static ServiceInfo ParseFsd(string fileName, string text)
+		{
+			var parser = new FsdParser(new FsdParserSettings { SupportsEvents = true });
+			return parser.ParseDefinition(new ServiceDefinitionText(fileName, text));
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- disable Scriban's default loop limit for Python template rendering so large schemas still generate successfully
- add a regression test that generates a type with 1001 fields

## Testing

- `dotnet test tests\Facility.CodeGen.Python.UnitTests\Facility.CodeGen.Python.UnitTests.csproj --nologo --verbosity minimal`
- `build.ps1 test`
- `dotnet run --project src\fsdgenpython -c Release -- C:\Code\Web\GuidesApi\fsd\GuidesApi.v1.fsd <temp output> --clean --newline lf`
